### PR TITLE
feat(auth): add JWT interceptor and secure ChatService endpoints

### DIFF
--- a/services/chat-service/.gitignore
+++ b/services/chat-service/.gitignore
@@ -1,4 +1,9 @@
+# macOS system files
+.DS_Store
+**/.DS_Store
+
 .idea
 .env
+.env.docker
 
 !*.example

--- a/services/chat-service/internal/config/config.go
+++ b/services/chat-service/internal/config/config.go
@@ -1,7 +1,3 @@
-// Package config provides configuration loading and parsing for the user-service.
-// It supports YAML-based config files and environment variable expansion, enabling
-// flexible deployment and adherence to the Single Responsibility and Dependency
-// Inversion principles.
 package config
 
 import (
@@ -14,91 +10,95 @@ import (
 )
 
 // Config holds all configuration for the user-service, including server, gRPC,
-// database, security, logging. It is designed for extension
-// without modification (Open/Closed Principle).
+// database, security, logging, and JWT settings.
 type Config struct {
-	Env      string     `yaml:"env"`
-	Server   Server     `yaml:"server"`
-	GRPC     GRPCConfig `yaml:"grpc"`
-	Database Database   `yaml:"database"`
-	Security Security   `yaml:"security"`
-	Logging  Logging    `yaml:"logging"`
+	Env      string     `yaml:"env"`      // Application environment (e.g., "development", "production")
+	Server   Server     `yaml:"server"`   // HTTP server settings
+	GRPC     GRPCConfig `yaml:"grpc"`     // gRPC server settings
+	Database Database   `yaml:"database"` // Database connection settings
+	Security Security   `yaml:"security"` // Security-related settings (e.g., CORS)
+	Logging  Logging    `yaml:"logging"`  // Logging level and format
+	JWT      JWT        `yaml:"jwt"`      // JWT signing
 }
 
 // Server contains HTTP server configuration parameters.
 type Server struct {
-	Host  string `yaml:"host"`
-	Port  string `yaml:"port"`
-	Debug bool   `yaml:"debug"`
+	Host  string `yaml:"host"`  // Server host address
+	Port  string `yaml:"port"`  // Server port
+	Debug bool   `yaml:"debug"` // Debug mode flag
 }
 
-// KeepaliveConfig defines gRPC keepalive settings.
+// KeepaliveConfig defines gRPC keepalive settings for connection health checks.
 type KeepaliveConfig struct {
-	Time    time.Duration `yaml:"time"`
-	Timeout time.Duration `yaml:"timeout"`
+	Time    time.Duration `yaml:"time"`    // Interval between pings
+	Timeout time.Duration `yaml:"timeout"` // Timeout for ping ack
 }
 
 // TLSConfig holds TLS settings for secure gRPC communication.
 type TLSConfig struct {
-	Enabled  bool   `yaml:"enabled"`
-	CertFile string `yaml:"cert_file"`
-	KeyFile  string `yaml:"key_file"`
+	Enabled  bool   `yaml:"enabled"`   // Enable TLS encryption
+	CertFile string `yaml:"cert_file"` // Path to TLS certificate file
+	KeyFile  string `yaml:"key_file"`  // Path to TLS key file
 }
 
 // GRPCConfig contains gRPC server configuration parameters.
 type GRPCConfig struct {
-	Host                 string          `yaml:"host"`
-	Port                 int             `yaml:"port"`
-	MaxConcurrentStreams uint32          `yaml:"max_concurrent_streams"`
-	Keepalive            KeepaliveConfig `yaml:"keepalive"`
-	TLS                  TLSConfig       `yaml:"tls"`
+	Host                 string          `yaml:"host"`                   // gRPC server host
+	Port                 int             `yaml:"port"`                   // gRPC server port
+	MaxConcurrentStreams uint32          `yaml:"max_concurrent_streams"` // Max parallel RPC streams
+	Keepalive            KeepaliveConfig `yaml:"keepalive"`              // Keepalive settings
+	TLS                  TLSConfig       `yaml:"tls"`                    // TLS configuration
 }
 
 // Database holds database connection configuration.
 type Database struct {
-	Driver   string `yaml:"driver"`
-	Host     string `yaml:"host"`
-	Port     int    `yaml:"port"`
-	User     string `yaml:"user"`
-	Password string `yaml:"password"`
-	Name     string `yaml:"name"`
-	SSLMode  string `yaml:"sslmode"`
+	Driver   string `yaml:"driver"`   // Database driver (e.g., "postgres")
+	Host     string `yaml:"host"`     // Database host address
+	Port     int    `yaml:"port"`     // Database port
+	User     string `yaml:"user"`     // Database user
+	Password string `yaml:"password"` // Database password
+	Name     string `yaml:"name"`     // Database name
+	SSLMode  string `yaml:"sslmode"`  // SSL mode (e.g., "disable", "require")
+}
+
+// JWT contains JWT signing secret and token expiry settings.
+type JWT struct {
+	Secret string `yaml:"secret"` // Secret key for signing JWT tokens
 }
 
 // Security holds security-related configuration, such as allowed CORS origins.
 type Security struct {
-	AllowedOrigins []string `yaml:"allowed_origins"`
+	AllowedOrigins []string `yaml:"allowed_origins"` // List of allowed CORS origins
 }
 
 // Logging defines logging level and format configuration.
 type Logging struct {
-	Level  string `yaml:"level"`
-	Format string `yaml:"format"`
+	Level  string `yaml:"level"`  // Log level (e.g., "info", "debug")
+	Format string `yaml:"format"` // Log output format (e.g., "json", "text")
 }
 
-// Load reads and parses the configuration from the given YAML file path, expanding
-// environment variables. It returns a Config struct or an error. This function
-// enables Dependency Inversion by decoupling config source from consumers.
+// Load reads and parses the YAML configuration from the specified file path.
+// It loads environment variables from a .env file, expands them in the YAML,
+// and unmarshals into a Config struct. Returns an error on failure.
 func Load(path string) (*Config, error) {
-	var cfg Config
-
 	if err := godotenv.Load(".env"); err == nil {
-		slog.Info("Environment variables loaded from .env files")
+		slog.Info("Loaded environment variables from .env file")
 	}
 
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		slog.Error("Failed to read config file", "err", err)
+		slog.Error("Failed to read config file", "error", err)
 		return nil, err
 	}
 
 	expanded := os.ExpandEnv(string(raw))
 
+	var cfg Config
 	if err := yaml.Unmarshal([]byte(expanded), &cfg); err != nil {
-		slog.Error("Failed to parse YAML config", "err", err)
+		slog.Error("Failed to parse YAML config", "error", err)
 		return nil, err
 	}
 
-	slog.Info("Config loaded successfully", "env", cfg.Env)
+	slog.Info("Configuration loaded successfully", "environment", cfg.Env)
 	return &cfg, nil
 }

--- a/services/chat-service/internal/dto/room.go
+++ b/services/chat-service/internal/dto/room.go
@@ -3,9 +3,11 @@ package dto
 import "time"
 
 // Room represents the JSON payload for a chat room.
+// Fields are exported for JSON marshalling and annotated with
+// `json` tags to define key names in HTTP responses.
 type Room struct {
-	ID            string    `json:"id"`
-	InitiatorID   int64     `json:"initiator_id"`
-	ParticipantID int64     `json:"participant_id"`
-	CreatedAt     time.Time `json:"created_at"`
+	ID            string    `json:"id"`             // Unique room identifier (UUID)
+	InitiatorID   int64     `json:"initiator_id"`   // ID of the user who created the room
+	ParticipantID int64     `json:"participant_id"` // ID of the other participant in the room
+	CreatedAt     time.Time `json:"created_at"`     // Timestamp when the room was created
 }

--- a/services/chat-service/internal/errs/errors.go
+++ b/services/chat-service/internal/errs/errors.go
@@ -1,6 +1,3 @@
-// Package errs defines domain, database, authentication, and validation errors
-// for the chat-service. It centralizes error values for consistent handling and
-// supports the Single Responsibility and Open/Closed principles.
 package errs
 
 import "errors"
@@ -10,4 +7,14 @@ var (
 	ErrInternal = errors.New("domain error")
 	// ErrDBFailure indicates a database operation failure.
 	ErrDBFailure = errors.New("database failure")
+
+	// ErrMissingMetadata indicates missing required metadata in a request.
+	ErrMissingMetadata = errors.New("missing metadata")
+	// ErrUnexpectedSigningMethod indicates an unexpected JWT signing method.
+	ErrUnexpectedSigningMethod = errors.New("unexpected JWT signing method")
+
+	// ErrMissingAuthToken indicates that an authorization token was not supplied.
+	ErrMissingAuthToken = errors.New("authorization token is not supplied")
+	// ErrInvalidToken indicates an invalid JWT token.
+	ErrInvalidToken = errors.New("invalid token")
 )

--- a/services/chat-service/internal/logger/logger.go
+++ b/services/chat-service/internal/logger/logger.go
@@ -1,4 +1,3 @@
-// logger.go
 package logger
 
 import (

--- a/services/chat-service/internal/mapper/converter.go
+++ b/services/chat-service/internal/mapper/converter.go
@@ -1,4 +1,3 @@
-// Package mapper provides a top-level entrypoint for all domain mappers.
 package mapper
 
 // Mappers groups every service-specific mapper under one struct,

--- a/services/chat-service/internal/mapper/room_service_mapper.go
+++ b/services/chat-service/internal/mapper/room_service_mapper.go
@@ -1,4 +1,3 @@
-// Package mapper handles conversions between DTOs, models, and gRPC messages.
 package mapper
 
 import (

--- a/services/chat-service/internal/middleware/unary_auth_interceptor.go
+++ b/services/chat-service/internal/middleware/unary_auth_interceptor.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/mamataliev-dev/social-platform/services/chat-service/internal/errs"
+)
+
+// UnaryAuthInterceptor intercepts unary gRPC calls to enforce JWT authentication.
+// It extracts the 'Authorization' header from metadata, validates the Bearer token,
+// and ensures the JWT signature and claims are correct before invoking the handler.
+func UnaryAuthInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+
+	var jwtSecret = []byte(os.Getenv("JWT_SECRET"))
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, errs.ErrMissingMetadata.Error())
+	}
+
+	authHeader := md["authorization"]
+	if len(authHeader) == 0 {
+		return nil, status.Error(codes.Unauthenticated, errs.ErrMissingAuthToken.Error())
+	}
+
+	tokenStr := strings.TrimPrefix(authHeader[0], "Bearer ")
+	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, status.Error(codes.Unauthenticated, errs.ErrUnexpectedSigningMethod.Error())
+		}
+		return jwtSecret, nil
+	})
+
+	if err != nil || !token.Valid {
+		return nil, status.Error(codes.Unauthenticated, errs.ErrInvalidToken.Error())
+	}
+
+	return handler(ctx, req)
+}

--- a/services/chat-service/internal/model/room.go
+++ b/services/chat-service/internal/model/room.go
@@ -1,5 +1,3 @@
-// Package model defines the core domain types and repository interfaces
-// for the chat service.
 package model
 
 import (
@@ -8,15 +6,19 @@ import (
 )
 
 // Room represents a chat room between two participants.
+// - ID: unique identifier assigned upon creation.
+// - InitiatorID: user ID of the room creator.
+// - ParticipantID: user ID of the other participant.
+// - CreatedAt: timestamp when the room was created.
 type Room struct {
-	ID            string
-	InitiatorID   int64
-	ParticipantID int64
-	CreatedAt     time.Time
+	ID            string    // unique room UUID
+	InitiatorID   int64     // creator's user ID
+	ParticipantID int64     // other participant's user ID
+	CreatedAt     time.Time // creation timestamp
 }
 
-// RoomRepository defines persistence operations for Room.
-// Implementations handle storage and retrieval of chat rooms.
+// RoomRepository defines persistence operations for chat rooms.
+// Implementers must handle storage and retrieval of Room entities.
 type RoomRepository interface {
 	// CreateRoom stores a new Room in the backing store and returns
 	// the Room populated with ID and CreatedAt, or an error on failure.

--- a/services/chat-service/internal/repository/postgres_setup.go
+++ b/services/chat-service/internal/repository/postgres_setup.go
@@ -1,5 +1,3 @@
-// Package repository provides database connection setup for the user-service.
-// It supports Dependency Inversion by abstracting database initialization.
 package repository
 
 import (
@@ -12,6 +10,9 @@ import (
 	"github.com/mamataliev-dev/social-platform/services/chat-service/internal/config"
 )
 
+// NewPostgresConnection initializes and verifies a PostgreSQL connection.
+// It constructs the DSN from cfg, opens the connection, pings to ensure availability,
+// and logs success. Returns the *sql.DB or an error if any step fails.
 func NewPostgresConnection(cfg *config.Config) (*sql.DB, error) {
 	dsn := fmt.Sprintf(
 		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",

--- a/services/chat-service/internal/repository/room_repository.go
+++ b/services/chat-service/internal/repository/room_repository.go
@@ -1,4 +1,3 @@
-// Package repository provides PostgreSQL implementations of chat-service repositories.
 package repository
 
 import (

--- a/services/chat-service/internal/tests/middleware/unary_auth_interceptor_test.go
+++ b/services/chat-service/internal/tests/middleware/unary_auth_interceptor_test.go
@@ -1,0 +1,42 @@
+package middleware_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/mamataliev-dev/social-platform/services/chat-service/internal/middleware"
+)
+
+// TestUnaryAuthInterceptor_MissingMetadata ensures that a request to a protected
+// method without any metadata fails with an Unauthenticated error.
+func TestUnaryAuthInterceptor_MissingMetadata(t *testing.T) {
+	info := &grpc.UnaryServerInfo{FullMethod: "/chat.v1.ChatService/CreateRoom"}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "should not be called", nil
+	}
+
+	_, err := middleware.UnaryAuthInterceptor(context.Background(), nil, info, handler)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+}
+
+// TestUnaryAuthInterceptor_InvalidToken ensures that a request with a malformed
+// or invalid JWT token fails with an Unauthenticated error.
+func TestUnaryAuthInterceptor_InvalidToken(t *testing.T) {
+	md := metadata.Pairs("authorization", "Bearer invalid-token")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	info := &grpc.UnaryServerInfo{FullMethod: "/chat.v1.ChatService/CreateRoom"}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "should not be called", nil
+	}
+
+	_, err := middleware.UnaryAuthInterceptor(ctx, nil, info, handler)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+}


### PR DESCRIPTION
- Implemented global UnaryAuthInterceptor to verify JWT access tokens
- Applied auth middleware to all ChatService RPCs
- Added unit tests for UnaryAuthInterceptor
- Updated config to include JWT-related settings
- Removed redundant comments in ChatService codebase